### PR TITLE
Fix settings link not switching to module tab fixes #667

### DIFF
--- a/extension/data/modules/modbar.js
+++ b/extension/data/modules/modbar.js
@@ -542,10 +542,10 @@ export default new Module({
             }
 
             // Wait a sec for stuff to load.
-            setTimeout(() => {
+            setTimeout(async () => {
                 // prevent tbsetting URL hash from persisting on reload.
                 history.pushState('', document.title, window.location.pathname);
-                TBModule.showSettings();
+                await TBModule.showSettings();
                 switchTab(module);
             }, 500);
         }


### PR DESCRIPTION
When opening a settings link it tried to switch to the settings tab before it was loaded.

Fixes #667

As a side note, the way we do setting highlighting is really janky, I feel like there must be a better way to do that. But that is something for a future PR. 