### PR TITLE
WIP for #716 - "New modmail: Option to always reply as self"

### DIFF
--- a/extension/data/modules/newmodmailpro.js
+++ b/extension/data/modules/newmodmailpro.js
@@ -48,12 +48,17 @@ export default new Module({
             description: 'Open modmail in nightmode',
         },
         {
-            id: 'noReplyAsSelf',
-            type: 'boolean',
-            default: false,
+            id: 'modmailReplyAs',
+            type: 'selector',
+            values: [
+                'Leave Unchanged',
+                'Reply as Myself',
+                'Reply as the subreddit',
+                'Create a Private Moderator Note',
+            ],
+            default: 'leave_unchanged',
             advanced: true,
-            description:
-                'Automatically switch "reply as" selection away from "Reply as myself" to "Reply as subreddit".',
+            description: 'Automatically switch "reply as" selection',
         },
         {
             id: 'showModmailPreview',
@@ -90,7 +95,7 @@ export default new Module({
 }, ({
     modmailnightmode: modMailNightmode,
     lastreplytypecheck: lastReplyTypeCheck,
-    noReplyAsSelf,
+    modmailReplyAs,
     showModmailPreview,
     clickableReason,
     sourceButton,
@@ -101,11 +106,23 @@ export default new Module({
 }) => {
     const $body = $('body');
 
-    function switchAwayFromReplyAsSelf () {
-        const current = $('.ThreadViewerReplyForm__replyOptions .FancySelect__valueText').text();
-        if (current === 'Reply as myself') {
-            $body.find('.FancySelect__value').click();
-            $body.find('.FancySelect__option:contains("Reply as the subreddit")').click();
+    function switchReplyAs () {
+        // Currently this is only working cosmetically; it'll change the text, but none of the ways I've tried here actually propogate and change
+        $body.find('#native-select-option').trigger('click');
+        switch (modmailReplyAs) {
+            case 'reply_as_myself':
+                $body.find('#native-select-option').val('null').trigger('click');
+                break;
+
+            case 'reply_as_the_subreddit':
+                $body.find('#native-select-option').val('isAuthorHidden').trigger('change');
+                break;
+
+            case 'create_a_private_moderator_note':
+                $body.find('#native-select-option').val('isInternal').trigger('change');
+                break;
+            default:
+                break;
         }
     }
 
@@ -248,11 +265,11 @@ export default new Module({
             submitReplyForm();
         };
 
-        if (noReplyAsSelf) {
+        if (modmailReplyAs !== 'leave_unchanged') {
             window.addEventListener('TBNewPage', event => {
                 if (event.detail.pageType === 'modmailConversation') {
                     setTimeout(() => {
-                        switchAwayFromReplyAsSelf();
+                        switchReplyAs();
                     }, 1000);
                 }
             });


### PR DESCRIPTION
This is a Work-in-progress pull request for #716 - "New modmail: Option to always reply as self".

Having a seperate toggle for always replying as self would be problematic, because one could run into potentially unexpected behavior if selecting both "always reply as self" and "always reply as subreddit", so I've opted for a toggle which would allow you to default to any of the three reply options, or to leave that setting unchanged from what Reddit defaults it to. 

This is a work in progress because I've run into a roadblock I haven't been able to sort out - at some point, Reddit changed the classes for the select, and the old code ([lines 104-110](https://github.com/toolbox-team/reddit-moderator-toolbox/blob/6016a03a7a02c887bef3c2c0ed4b0566e63d698e/extension/data/modules/newmodmailpro.js#L104-L110)) doesn't actually work anymore to be able to use as a guide. The code I've offered as a replacement visually toggles the option, but does not actually trigger the change in reply type which happens if an option on the dropdown is manually clicked.

My proficiency with Javascript is somewhere hovering around "knows just enough to be dangerous", so I'm hoping that what I've provided is useful, and getting this across the finish line will be simple for someone who knows more than me.