### PR TITLE
Don't include AI-generated user summaries in the mod notes button

### DIFF
--- a/extension/data/modules/modnotes.jsx
+++ b/extension/data/modules/modnotes.jsx
@@ -13,7 +13,7 @@ import {Module} from '../tbmodule.jsx';
 import {drawPosition, textFeedback, TextFeedbackKind} from '../tbui.js';
 import createLogger from '../util/logging.ts';
 import {setSettingAsync} from '../util/settings.ts';
-import {createBodyShadowPortal, reactRenderer} from '../util/ui_interop.tsx';
+import {classes, createBodyShadowPortal, reactRenderer} from '../util/ui_interop.tsx';
 
 import {
     ActionButton,
@@ -308,7 +308,7 @@ function ModNotesBadge ({
     }
     return (
         <BracketButton
-            className='tb-bracket-button tb-modnote-badge'
+            className={classes('tb-bracket-button', 'tb-modnote-badge', css.noteButton)}
             tabIndex='0'
             title={`Mod notes for /u/${user} in /r/${subreddit}`}
             onClick={onClick}

--- a/extension/data/modules/modnotes.module.css
+++ b/extension/data/modules/modnotes.module.css
@@ -1,3 +1,9 @@
+.noteButton {
+	max-width: 200px;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
 .noteTable {
 	/* The modnote popup footer is very wide; fill up that extra width */
 	width: 100%;


### PR DESCRIPTION
[reddit why](https://www.reddit.com/r/toolbox/comments/1oed0nh/ai_user_summery_cluttering_new_notes_label/)

Also limits the modnotes button to 200px wide, which I thought I already did, but oh well.

backport to v6