### PR TITLE
update release script to use new inquirer packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
                 "webextension-polyfill": "^0.12.0"
             },
             "devDependencies": {
+                "@inquirer/input": "^4.2.5",
+                "@inquirer/select": "^4.4.0",
                 "@rollup/plugin-commonjs": "^28.0.0",
                 "@rollup/plugin-node-resolve": "^16.0.0",
                 "@rollup/plugin-replace": "^6.0.1",
@@ -41,7 +43,6 @@
                 "eslint": "^8.57.0",
                 "eslint-plugin-import": "^2.32.0",
                 "eslint-plugin-react": "^7.37.2",
-                "inquirer": "^12.9.0",
                 "jsdoc": "^4.0.2",
                 "rollup": "^4.9.6",
                 "rollup-plugin-copy": "^3.5.0",
@@ -302,63 +303,26 @@
             "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
             "dev": true
         },
-        "node_modules/@inquirer/checkbox": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.0.tgz",
-            "integrity": "sha512-fdSw07FLJEU5vbpOPzXo5c6xmMGDzbZE2+niuDHX5N6mc6V0Ebso/q3xiHra4D73+PMsC8MJmcaZKuAAoaQsSA==",
+        "node_modules/@inquirer/ansi": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.1.tgz",
+            "integrity": "sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/figures": "^1.0.13",
-                "@inquirer/type": "^3.0.8",
-                "ansi-escapes": "^4.3.2",
-                "yoctocolors-cjs": "^2.1.2"
-            },
             "engines": {
                 "node": ">=18"
-            },
-            "peerDependencies": {
-                "@types/node": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@inquirer/confirm": {
-            "version": "5.1.14",
-            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
-            "integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@types/node": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@inquirer/core": {
-            "version": "10.1.15",
-            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
-            "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.0.tgz",
+            "integrity": "sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/figures": "^1.0.13",
-                "@inquirer/type": "^3.0.8",
-                "ansi-escapes": "^4.3.2",
+                "@inquirer/ansi": "^1.0.1",
+                "@inquirer/figures": "^1.0.14",
+                "@inquirer/type": "^3.0.9",
                 "cli-width": "^4.1.0",
                 "mute-stream": "^2.0.0",
                 "signal-exit": "^4.1.0",
@@ -377,56 +341,10 @@
                 }
             }
         },
-        "node_modules/@inquirer/editor": {
-            "version": "4.2.15",
-            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.15.tgz",
-            "integrity": "sha512-wst31XT8DnGOSS4nNJDIklGKnf+8shuauVrWzgKegWUe28zfCftcWZ2vktGdzJgcylWSS2SrDnYUb6alZcwnCQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8",
-                "external-editor": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@types/node": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@inquirer/expand": {
-            "version": "4.0.17",
-            "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.17.tgz",
-            "integrity": "sha512-PSqy9VmJx/VbE3CT453yOfNa+PykpKg/0SYP7odez1/NWBGuDXgPhp4AeGYYKjhLn5lUUavVS/JbeYMPdH50Mw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8",
-                "yoctocolors-cjs": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@types/node": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@inquirer/figures": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
-            "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.14.tgz",
+            "integrity": "sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -434,136 +352,14 @@
             }
         },
         "node_modules/@inquirer/input": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.1.tgz",
-            "integrity": "sha512-tVC+O1rBl0lJpoUZv4xY+WGWY8V5b0zxU1XDsMsIHYregdh7bN5X5QnIONNBAl0K765FYlAfNHS2Bhn7SSOVow==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.5.tgz",
+            "integrity": "sha512-7GoWev7P6s7t0oJbenH0eQ0ThNdDJbEAEtVt9vsrYZ9FulIokvd823yLyhQlWHJPGce1wzP53ttfdCZmonMHyA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@types/node": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@inquirer/number": {
-            "version": "3.0.17",
-            "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.17.tgz",
-            "integrity": "sha512-GcvGHkyIgfZgVnnimURdOueMk0CztycfC8NZTiIY9arIAkeOgt6zG57G+7vC59Jns3UX27LMkPKnKWAOF5xEYg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@types/node": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@inquirer/password": {
-            "version": "4.0.17",
-            "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.17.tgz",
-            "integrity": "sha512-DJolTnNeZ00E1+1TW+8614F7rOJJCM4y4BAGQ3Gq6kQIG+OJ4zr3GLjIjVVJCbKsk2jmkmv6v2kQuN/vriHdZA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8",
-                "ansi-escapes": "^4.3.2"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@types/node": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@inquirer/prompts": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.0.tgz",
-            "integrity": "sha512-JHwGbQ6wjf1dxxnalDYpZwZxUEosT+6CPGD9Zh4sm9WXdtUp9XODCQD3NjSTmu+0OAyxWXNOqf0spjIymJa2Tw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/checkbox": "^4.2.0",
-                "@inquirer/confirm": "^5.1.14",
-                "@inquirer/editor": "^4.2.15",
-                "@inquirer/expand": "^4.0.17",
-                "@inquirer/input": "^4.2.1",
-                "@inquirer/number": "^3.0.17",
-                "@inquirer/password": "^4.0.17",
-                "@inquirer/rawlist": "^4.1.5",
-                "@inquirer/search": "^3.1.0",
-                "@inquirer/select": "^4.3.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@types/node": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@inquirer/rawlist": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.5.tgz",
-            "integrity": "sha512-R5qMyGJqtDdi4Ht521iAkNqyB6p2UPuZUbMifakg1sWtu24gc2Z8CJuw8rP081OckNDMgtDCuLe42Q2Kr3BolA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/type": "^3.0.8",
-                "yoctocolors-cjs": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@types/node": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@inquirer/search": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.1.0.tgz",
-            "integrity": "sha512-PMk1+O/WBcYJDq2H7foV0aAZSmDdkzZB9Mw2v/DmONRJopwA/128cS9M/TXWLKKdEQKZnKwBzqu2G4x/2Nqx8Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/figures": "^1.0.13",
-                "@inquirer/type": "^3.0.8",
-                "yoctocolors-cjs": "^2.1.2"
+                "@inquirer/core": "^10.3.0",
+                "@inquirer/type": "^3.0.9"
             },
             "engines": {
                 "node": ">=18"
@@ -578,16 +374,16 @@
             }
         },
         "node_modules/@inquirer/select": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.1.tgz",
-            "integrity": "sha512-Gfl/5sqOF5vS/LIrSndFgOh7jgoe0UXEizDqahFRkq5aJBLegZ6WjuMh/hVEJwlFQjyLq1z9fRtvUMkb7jM1LA==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.0.tgz",
+            "integrity": "sha512-kaC3FHsJZvVyIjYBs5Ih8y8Bj4P/QItQWrZW22WJax7zTN+ZPXVGuOM55vzbdCP9zKUiBd9iEJVdesujfF+cAA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/figures": "^1.0.13",
-                "@inquirer/type": "^3.0.8",
-                "ansi-escapes": "^4.3.2",
+                "@inquirer/ansi": "^1.0.1",
+                "@inquirer/core": "^10.3.0",
+                "@inquirer/figures": "^1.0.14",
+                "@inquirer/type": "^3.0.9",
                 "yoctocolors-cjs": "^2.1.2"
             },
             "engines": {
@@ -603,9 +399,9 @@
             }
         },
         "node_modules/@inquirer/type": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
-            "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.9.tgz",
+            "integrity": "sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1093,35 +889,6 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/ansi-escapes": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "type-fest": "^0.21.3"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/ansi-escapes/node_modules/type-fest": {
-            "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1542,13 +1309,6 @@
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
-        },
-        "node_modules/chardet": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/cli-width": {
             "version": "4.1.0",
@@ -2658,21 +2418,6 @@
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
             "dev": true
         },
-        "node_modules/external-editor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chardet": "^0.7.0",
-                "iconv-lite": "^0.4.24",
-                "tmp": "^0.0.33"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3167,19 +2912,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/icss-replace-symbols": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
@@ -3289,33 +3021,6 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
-        },
-        "node_modules/inquirer": {
-            "version": "12.9.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.0.tgz",
-            "integrity": "sha512-LlFVmvWVCun7uEgPB3vups9NzBrjJn48kRNtFGw3xU1H5UXExTEz/oF1JGLaB0fvlkUB+W6JfgLcSEaSdH7RPA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^10.1.15",
-                "@inquirer/prompts": "^7.8.0",
-                "@inquirer/type": "^3.0.8",
-                "ansi-escapes": "^4.3.2",
-                "mute-stream": "^2.0.0",
-                "run-async": "^4.0.5",
-                "rxjs": "^7.8.2"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@types/node": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/internal-slot": {
             "version": "1.1.0",
@@ -4417,16 +4122,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/own-keys": {
@@ -5587,16 +5282,6 @@
             "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
             "dev": true
         },
-        "node_modules/run-async": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.5.tgz",
-            "integrity": "sha512-oN9GTgxUNDBumHTTDmQ8dep6VIJbgj9S3dPP+9XylVLIK4xB9XTXtKWROd5pnhdXR9k0EgO1JRcNh0T+Ny2FsA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.12.0"
-            }
-        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5618,16 +5303,6 @@
             ],
             "dependencies": {
                 "queue-microtask": "^1.2.2"
-            }
-        },
-        "node_modules/rxjs": {
-            "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.1.0"
             }
         },
         "node_modules/safe-array-concat": {
@@ -5690,13 +5365,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/scheduler": {
             "version": "0.26.0",
@@ -6163,19 +5831,6 @@
             "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
             "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
         },
-        "node_modules/tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "os-tmpdir": "~1.0.2"
-            },
-            "engines": {
-                "node": ">=0.6.0"
-            }
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6592,9 +6247,9 @@
             }
         },
         "node_modules/yoctocolors-cjs": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
-            "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+            "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
         "webextension-polyfill": "^0.12.0"
     },
     "devDependencies": {
+        "@inquirer/input": "^4.2.5",
+        "@inquirer/select": "^4.4.0",
         "@rollup/plugin-commonjs": "^28.0.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@rollup/plugin-replace": "^6.0.1",
@@ -54,7 +56,6 @@
         "eslint": "^8.57.0",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-react": "^7.37.2",
-        "inquirer": "^12.9.0",
         "jsdoc": "^4.0.2",
         "rollup": "^4.9.6",
         "rollup-plugin-copy": "^3.5.0",


### PR DESCRIPTION
Supersedes #1122; migrates to the new inquirer api that uses different packages for different types of inputs. yay fewer dependencies