### PR TITLE
Invalidate access tokens when session id changes

### DIFF
--- a/extension/data/background/handlers/cache.js
+++ b/extension/data/background/handlers/cache.js
@@ -95,10 +95,9 @@ async function getSessionUserID (sender) {
     }
 
     if (redditSessionCookie) {
-        // The session value contains comma seperated values. The first one is the the userid in base10.
-        // As reddit uses base36 everywhere else we convert the ID to that so things are easier to debug.
-        const redditUserIdBase10 = decodeURIComponent(redditSessionCookie.value).match(/\d+/)[0];
-        redditUserIdBase36 = parseInt(redditUserIdBase10).toString(36);
+        // this cookie is a JWT now, fun. decode its payload and get the
+        // `sub`ject, removing `t3_`
+        redditUserIdBase36 = JSON.parse(atob(redditSessionCookie.value.split('.')[1])).sub.slice(3);
     } else {
         redditUserIdBase36 = 'noSessionFallback';
     }


### PR DESCRIPTION
Previously we didn't bother caching our OAuth access token because we grabbed it directly out of a cookie in new Modmail, and that was cheap. Modmail went away and #1138 lets us get a token from Shreddit by exchanging a CSRF token for an access token, but this means making a request to Shreddit in order to use an access token, so we now cache the token. Caching the token without being aware of when the Reddit session changes causes issues where Reddit invalidates the token when the user logs out, but Toolbox doesn't know and continues to make requests with the bad token until it was originally supposed to expire.

This PR hacks around this by using part of the `reddit_session` cookie as the storage key for the cached access token, meaning that a new access token will be retrieved whenever the session changes. This makes Toolbox work again when switching accounts.

Also fixes the per-user cache logic to decode the new `reddit_session` format and get the current user's base36 ID from it (it's now a JWT and not just a random string of values, with the user's fullname as the JWT `sub`ject).