### PR TITLE
Add Safari Web Extension build target

### DIFF
--- a/extension/data/background/handlers/notifications.js
+++ b/extension/data/background/handlers/notifications.js
@@ -12,12 +12,21 @@ import {makeRequest} from './webrequest';
  */
 const notificationMetaDataKey = notificationID => `notifmeta-${notificationID}`;
 
+// Safari does not support browser.storage.session. Use an in-memory Map as a
+// session-scoped fallback for notification metadata (ephemeral by design).
+const sessionStorageFallback = new Map();
+const hasSessionStorage = browser.storage.session != null;
+
 /**
  * Sets the notification ID and meta data object for a given notification.
  * @param notificationID string notificationID
  * @param notificationObject object containing the meta data
  */
 function setNotificationMetaData (notificationID, notificationObject) {
+    if (!hasSessionStorage) {
+        sessionStorageFallback.set(notificationMetaDataKey(notificationID), notificationObject);
+        return Promise.resolve();
+    }
     return browser.storage.session.set({
         [notificationMetaDataKey(notificationID)]: notificationObject,
     });
@@ -29,6 +38,10 @@ function setNotificationMetaData (notificationID, notificationObject) {
  * @returns {Promise<object>}
  */
 function getNotificationMetaData (notificationID) {
+    if (!hasSessionStorage) {
+        const key = notificationMetaDataKey(notificationID);
+        return Promise.resolve({[key]: sessionStorageFallback.get(key) ?? null});
+    }
     return browser.storage.session.get({[notificationMetaDataKey(notificationID)]: null});
 }
 
@@ -38,6 +51,10 @@ function getNotificationMetaData (notificationID) {
  * @returns {promise<object>}
  */
 function deleteNotificationMetaData (notificationID) {
+    if (!hasSessionStorage) {
+        sessionStorageFallback.delete(notificationMetaDataKey(notificationID));
+        return Promise.resolve();
+    }
     return browser.storage.session.remove(notificationMetaDataKey(notificationID));
 }
 
@@ -114,7 +131,8 @@ browser.alarms.onAlarm.addListener(alarmInfo => {
 
 // Handle notification creation
 messageHandlers.set('tb-notification', async request => {
-    const sendNotification = request.native ? sendNativeNotification : sendPageNotification;
+    const useNative = request.native && browser.notifications != null;
+    const sendNotification = useNative ? sendNativeNotification : sendPageNotification;
     const notificationID = await sendNotification(request.details);
     // The Alarms API is baffling simplistic and limited.
     // Because of that the ID will be send back to the tab that requested the notification and a timeout used there to relay back to the background worker.
@@ -135,7 +153,7 @@ async function clearNotification (notificationID) {
         // Notification has already been cleared
         return;
     }
-    if (metadata.type === 'native') {
+    if (metadata.type === 'native' && browser.notifications != null) {
         // Clear a native notification
         browser.notifications.clear(notificationID);
     } else {
@@ -202,9 +220,11 @@ messageHandlers.set('tb-page-notification-clear', request => {
 });
 
 // Handle events on native notifications
-browser.notifications.onClicked.addListener(onClickNotification);
-browser.notifications.onClosed.addListener(id => {
-    // Clearing native notifications is done for us, so we don't need to call
-    // clearNotification, but we do still need to clean up metadata.
-    deleteNotificationMetaData(id);
-});
+if (browser.notifications != null) {
+    browser.notifications.onClicked.addListener(onClickNotification);
+    browser.notifications.onClosed.addListener(id => {
+        // Clearing native notifications is done for us, so we don't need to call
+        // clearNotification, but we do still need to clean up metadata.
+        deleteNotificationMetaData(id);
+    });
+}

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -393,6 +393,20 @@ export function debugInformation () {
             debugObject.platformInformation = browserMatchedInfo[1];
             break;
         }
+        case SAFARI: {
+            const safariRegex = /\((.*?)\).*Version\/([0-9.]*).*Safari\//;
+            if (safariRegex.test(browserUserAgent)) {
+                browserMatchedInfo = browserUserAgent.match(safariRegex);
+                debugObject.browser = 'Safari';
+                debugObject.browserVersion = browserMatchedInfo[2];
+                debugObject.platformInformation = browserMatchedInfo[1];
+            } else {
+                debugObject.browser = 'Safari';
+                debugObject.browserVersion = 'Unknown';
+                debugObject.platformInformation = browserUserAgent;
+            }
+            break;
+        }
         case UNKNOWN_BROWSER: {
             debugObject.browser = 'Unknown';
             debugObject.browserVersion = 'Unknown';

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -295,6 +295,7 @@ const CHROME = 'chrome';
 const FIREFOX = 'firefox';
 const OPERA = 'opera';
 const EDGE = 'edge';
+const SAFARI = 'safari';
 const UNKNOWN_BROWSER = 'unknown';
 /** The name of the current browser. */
 export const browserName = typeof InstallTrigger !== 'undefined' || 'MozBoxSizing' in document.body.style
@@ -305,6 +306,8 @@ export const browserName = typeof InstallTrigger !== 'undefined' || 'MozBoxSizin
         : navigator.userAgent.includes(' Edg/')
         ? EDGE
         : CHROME
+    : navigator.vendor.includes('Apple')
+    ? SAFARI
     : UNKNOWN_BROWSER;
 
 /**
@@ -593,6 +596,7 @@ export async function showNote (note) {
         || note.platform === 'chrome' && browserName !== CHROME
         || note.platform === 'opera' && browserName !== OPERA
         || note.platform === 'edge' && browserName !== EDGE
+        || note.platform === 'safari' && browserName !== SAFARI
     ) {
         return;
     }

--- a/extension/safari_manifest.json
+++ b/extension/safari_manifest.json
@@ -1,0 +1,101 @@
+{
+    "manifest_version": 3,
+    "name": "Moderator toolbox for reddit",
+    "author": "toolbox team",
+    "short_name": "toolbox",
+    "description": "A set of tools to be used by moderators on reddit in order to make their jobs easier.",
+    "version": "7.0.0.17",
+    "version_name": "7.0.0: \"Oh God Erin What Are You Doing\"",
+    "permissions": [
+        "cookies",
+        "tabs",
+        "storage",
+        "unlimitedStorage",
+        "webNavigation",
+        "alarms"
+    ],
+    "host_permissions": [
+        "https://*.reddit.com/",
+        "https://old.reddit.com/",
+        "https://oauth.reddit.com/",
+        "https://mod.reddit.com/"
+    ],
+    "icons": {
+        "16": "data/images/icon16.png",
+        "48": "data/images/icon48.png",
+        "128": "data/images/icon128.png"
+    },
+    "background": {
+        "service_worker": "data/background/index.js"
+    },
+    "content_scripts": [
+        {
+            "run_at": "document_end",
+            "all_frames": true,
+            "matches": [
+                "https://*.reddit.com/*"
+            ],
+            "exclude_matches": [
+                "https://*.reddit.com/framedGild/*",
+                "https://*.reddit.com/framedModal/*",
+                "https://*.reddit.com/chat/*",
+                "https://*.reddit.com/account/sso/*",
+                "https://ads.reddit.com/*",
+                "https://*.reddit.com/*.json",
+                "https://*.reddit.com/*.json?*",
+                "https://*.reddit.com/*.json-html",
+                "https://*.reddit.com/*.json-html?*"
+            ],
+            "css": [
+                "data/styles/toolbox.css",
+                "data/styles/tbui.css",
+                "data/styles/devtools.css",
+                "data/styles/support.css",
+                "data/styles/comment.css",
+                "data/styles/old_comment.css",
+                "data/styles/newmodmailpro.css",
+                "data/styles/removalreasons.css",
+                "data/styles/nukecomments.css",
+                "data/styles/personalnotes.css",
+                "data/styles/queuetools.css",
+                "data/styles/old_queuetools.css",
+                "data/styles/achievements.css",
+                "data/styles/modbar.css",
+                "data/styles/notifier.css",
+                "data/styles/usernotes.css",
+                "data/styles/config.css",
+                "data/styles/profile.css",
+                "data/styles/macros.css",
+                "data/styles/queue_overlay.css",
+                "data/styles/modmatrix.css",
+                "data/styles/codemirror/codemirror.css",
+                "data/styles/codemirror/dialog.css",
+                "data/styles/codemirror/fullscreen.css",
+                "data/styles/codemirror/matchesonscrollbar.css",
+                "data/styles/codemirror/show-hint.css",
+                "data/styles/codemirror/themes.css"
+            ],
+            "js": [
+                "data/init.js"
+            ]
+        }
+    ],
+    "web_accessible_resources": [
+        {
+            "resources": [
+                "/data/bundled.css",
+                "/data/styles/font/MaterialIcons-Regular.woff2",
+                "/data/styles/font/MaterialIcons-Regular.woff",
+                "/data/styles/font/MaterialIcons-Regular.ttf",
+                "/data/images/balloon.png",
+                "/data/images/snoo_up.png",
+                "/data/images/snoo_splat.png",
+                "/data/images/snoo_uh_oh.png",
+                "/data/images/snoo_running.gif"
+            ],
+            "matches": [
+                "<all_urls>"
+            ]
+        }
+    ]
+}

--- a/release.mjs
+++ b/release.mjs
@@ -27,9 +27,11 @@ const __dirname = path.dirname(__filename);
 
 const chromeManifestLocation = path.resolve(__dirname, 'extension/chrome_manifest.json');
 const firefoxManifestLocation = path.resolve(__dirname, 'extension/firefox_manifest.json');
+const safariManifestLocation = path.resolve(__dirname, 'extension/safari_manifest.json');
 
 const manifestContentChrome = JSON.parse(fs.readFileSync(chromeManifestLocation).toString());
 const manifestContentFirefox = JSON.parse(fs.readFileSync(firefoxManifestLocation).toString());
+const manifestContentSafari = JSON.parse(fs.readFileSync(safariManifestLocation).toString());
 
 const currentVersion = manifestContentChrome.version;
 const currentVersionName = manifestContentChrome.version_name.match(versionNameRegex)[1];
@@ -57,10 +59,12 @@ const currentVersionName = manifestContentChrome.version_name.match(versionNameR
     console.log('Writing update version information to manifest');
     manifestContentFirefox.version = newVersion;
     manifestContentChrome.version = newVersion;
+    manifestContentSafari.version = newVersion;
 
     const versionParts = newVersion.match(/(?<display>\d\d?\.\d\d?\.\d\d?)\.(?<build>\d+)$/).groups;
     manifestContentFirefox.version_name = `${versionParts.display}: "${newVersionName}"`;
     manifestContentChrome.version_name = `${versionParts.display}: "${newVersionName}"`;
+    manifestContentSafari.version_name = `${versionParts.display}: "${newVersionName}"`;
 
     fs.writeFileSync(
         chromeManifestLocation,
@@ -77,6 +81,17 @@ const currentVersionName = manifestContentChrome.version_name.match(versionNameR
         firefoxManifestLocation,
         // include trailing newline
         `${JSON.stringify(manifestContentFirefox, null, 4)}\n`,
+        'utf8',
+        err => {
+            if (err) {
+                throw err;
+            }
+        },
+    );
+    fs.writeFileSync(
+        safariManifestLocation,
+        // include trailing newline
+        `${JSON.stringify(manifestContentSafari, null, 4)}\n`,
         'utf8',
         err => {
             if (err) {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,7 +30,7 @@ if (buildType !== 'dev' && !buildSha) {
 }
 
 // TODO: Pull entry point info and copied files from manifest itself
-export default ['chrome', 'firefox'].flatMap(platform => [
+export default ['chrome', 'firefox', 'safari'].flatMap(platform => [
     {
         input: 'extension/data/init.ts',
         output: {


### PR DESCRIPTION
## Summary

- **New `extension/safari_manifest.json`** — MV3 manifest for Safari, derived from the Chrome manifest with `notifications` permission removed (unsupported in Safari) and `incognito: split` removed (unsupported in Safari)
- **`rollup.config.js`** — adds `'safari'` to the platform array so `npm run build` now produces `build/safari/` alongside `build/chrome/` and `build/firefox/`
- **`extension/data/background/handlers/notifications.js`** — four Safari compatibility fixes:
  - Falls back to an in-memory `Map` when `browser.storage.session` is unavailable
  - Guards `browser.notifications` before choosing native vs. page notification dispatch
  - Guards `browser.notifications.clear` in `clearNotification`
  - Wraps module-level `onClicked`/`onClosed` listener registration in a `browser.notifications != null` check (prevents service worker crash on startup)
- **`extension/data/tbcore.js`** — adds `SAFARI` browser constant, detects Safari via `navigator.vendor.includes('Apple')`, adds `safari` to the `showNote` platform filter, and adds a `case SAFARI` branch to `debugInformation()` (using `Version/x.x Safari/` UA regex) so debug info reports correctly instead of falling through to the "Error in browser detection" default
- **`release.mjs`** — loads `safari_manifest.json` and bumps `version`/`version_name` alongside the Chrome and Firefox manifests on each release

## Post-merge: one-time Xcode setup

After merging, run once to generate the Xcode project wrapper (requires Xcode command-line tools):

```sh
npm run build
xcrun safari-web-extension-converter build/safari \
    --project-location safari \
    --app-name "Moderator Toolbox" \
    --bundle-identifier "com.toolbox-team.moderator-toolbox" \
    --macos-only \
    --no-open
```

Commit the resulting `safari/` Xcode project. `build/safari/` is transient build output and should stay in `.gitignore` like `build/chrome/`.

## Test plan

- [ ] `npm run build` completes without errors and produces `build/chrome/`, `build/firefox/`, `build/safari/`
- [ ] `build/safari/manifest.json` is MV3, has no `notifications` permission, has no `incognito` key
- [ ] Load `build/safari/` in Safari via Developer → Allow Unsigned Extensions — extension loads without error
- [ ] No service worker crash in Safari Web Inspector console
- [ ] Triggering a notification shows an in-page notification (not native) on Safari
- [ ] Debug info panel on Safari shows `browser: "Safari"` with correct version, not `"Error in browser detection"`
- [ ] `node release.mjs` bumps version in all three manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)